### PR TITLE
Fixed error with incorrect parity for EAN 13 codes starting with 6

### DIFF
--- a/src/Zen.Barcode.Core/CodeEan13.cs
+++ b/src/Zen.Barcode.Core/CodeEan13.cs
@@ -362,7 +362,7 @@ namespace Zen.Barcode
 				0x0E, // OOEEEO
 				0x13, // OEOOEE
 				0x19, // OEEOOE
-				0x1D, // OEEEOE
+				0x1C, // OEEEOO
 				0x15, // OEOEOE
 				0x16, // OEOEEO
 				0x1A, // OEEOEO


### PR DESCRIPTION
Source: https://en.wikipedia.org/wiki/International_Article_Number#Binary_encoding_of_data_digits_into_EAN-13_barcode